### PR TITLE
Removing PaymentType from get_result request

### DIFF
--- a/epgpaymentpage/controllers/front/paymentservice.php
+++ b/epgpaymentpage/controllers/front/paymentservice.php
@@ -35,7 +35,7 @@ class paymentservice
             'name'  =>  'get_result',
             'url_link'  =>  '/tokenizer/getresult',
             'required_fields'  =>  array(
-                'MerchantId', 'MerchantGuid', 'PaymentType', 'TransactionType', 'Token', 'Format', 'IpAddress',
+                'MerchantId', 'MerchantGuid', 'TransactionType', 'Token', 'Format', 'IpAddress',
             ),
             'returnTo' =>  '',
         ),

--- a/epgpaymentpage/controllers/front/services/PaymentService.php
+++ b/epgpaymentpage/controllers/front/services/PaymentService.php
@@ -24,7 +24,7 @@ class PaymentService
             'name' => 'get_result',
             'url_link' => '/tokenizer/getresult',
             'required_fields' => array(
-                'MerchantId', 'MerchantGuid', 'PaymentType', 'TransactionType', 'Token', 'Format', 'IpAddress',
+                'MerchantId', 'MerchantGuid', 'TransactionType', 'Token', 'Format', 'IpAddress',
             ),
             'returnTo' => '',
         ),

--- a/epgpaymentpage/epgpaymentpage.php
+++ b/epgpaymentpage/epgpaymentpage.php
@@ -170,12 +170,15 @@ class Epgpaymentpage extends PaymentModule
             return false;
         }
 
+        static $error;
+        $error = $this->context->cookie->__get($this->epg_error_name) ?  $this->context->cookie->__get($this->epg_error_name) : $error ;
+
         $this->smarty->assign([
             'this_path' => $this->_path,
             'this_path_epg' => $this->_path,
             'this_path_ssl' => Tools::getShopDomainSsl(true, true) . __PS_BASE_URI__ . 'modules/' . $this->name . '/',
             'static_token' => Tools::getToken(false),
-            'this_error' => $this->context->cookie->__get($this->epg_error_name),
+            'this_error' => $error,
             'poTypes' => $this->poTypes
         ]);
 


### PR DESCRIPTION
- **Removing PaymentType from get_result request**  _(commit 7a502d5)_  
It seems "PaymentType" field shouldn't be required in the "get_result" request either. 

- **Static caching error message** _(commit 252cb3b)_  
I've set static caching variable to keep the error messages until the end of script execution. This way,if the Payment hook is executed multiple time the error message is not lost after unsetting the cookie.
